### PR TITLE
Fix missing flash message functions

### DIFF
--- a/inc/flash.php
+++ b/inc/flash.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Simple flash message helpers using session.
+ */
+function set_flash(string $message, string $type = 'success'): void {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    $_SESSION['flash'] = [$message, $type];
+}
+
+function display_flash(): void {
+    if (!empty($_SESSION['flash'])) {
+        [$message, $type] = $_SESSION['flash'];
+        unset($_SESSION['flash']);
+        $type = preg_replace('/[^a-z]/', '', $type) ?: 'info';
+        echo '<div class="alert alert-' . htmlspecialchars($type) . '">' . htmlspecialchars($message) . '</div>';
+    }
+}

--- a/inc/header.php
+++ b/inc/header.php
@@ -1,4 +1,7 @@
-<?php require_once __DIR__.'/config.php'; ?>
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/flash.php';
+?>
 <!doctype html>
 <html lang="fr">
 <head>
@@ -52,3 +55,4 @@
   </div>
 </nav>
 <div class="container">
+<?php display_flash(); ?>


### PR DESCRIPTION
## Summary
- implement `set_flash` and `display_flash` helpers
- include flash helper in header and show flash messages after nav

## Testing
- `php -l inc/flash.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f409a0e6c8328aae55960d913f920