### PR TITLE
Fix missing flash message functions

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -7,12 +7,18 @@ document.addEventListener('DOMContentLoaded',()=>{
 
 const toggle=document.getElementById('themeToggle');
 if(toggle){
+  const applyIcon=()=>{
+    toggle.innerHTML=document.body.classList.contains('dark')
+      ?'<i class="bi-sun"></i>'
+      :'<i class="bi-moon"></i>';
+  };
   if(localStorage.getItem('theme')==='dark' || (window.matchMedia('(prefers-color-scheme: dark)').matches && !localStorage.getItem('theme'))){
       document.body.classList.add('dark');
   }
+  applyIcon();
   toggle.addEventListener('click',()=>{
     document.body.classList.toggle('dark');
     localStorage.setItem('theme',document.body.classList.contains('dark')?'dark':'light');
-    toggle.innerHTML=document.body.classList.contains('dark')?'<i class="bi-sun"></i>':'<i class="bi-moon"></i>';
+    applyIcon();
   });
 }

--- a/inc/flash.php
+++ b/inc/flash.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Simple flash message helpers using session.
+ */
+function set_flash(string $message, string $type = 'success'): void {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    $_SESSION['flash'] = [$message, $type];
+}
+
+function display_flash(): void {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    if (!empty($_SESSION['flash'])) {
+        [$message, $type] = $_SESSION['flash'];
+        unset($_SESSION['flash']);
+        $type = preg_replace('/[^a-z]/', '', $type) ?: 'info';
+        echo '<div class="alert alert-' . htmlspecialchars($type) . ' alert-dismissible fade show" role="alert">'
+            . htmlspecialchars($message)
+            . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>'
+            . '</div>';
+    }
+}

--- a/inc/header.php
+++ b/inc/header.php
@@ -1,4 +1,7 @@
-<?php require_once __DIR__.'/config.php'; ?>
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/flash.php';
+?>
 <!doctype html>
 <html lang="fr">
 <head>
@@ -52,3 +55,4 @@
   </div>
 </nav>
 <div class="container">
+<?php display_flash(); ?>

--- a/verify.php
+++ b/verify.php
@@ -1,26 +1,26 @@
 <?php
-require_once 'inc/header.php';
+require_once 'inc/config.php';
+require_once 'inc/flash.php';
 
 $token = $_GET['token'] ?? '';
 if (!$token) {
-    echo '<div class="alert alert-danger">Token manquant.</div>';
-    require_once 'inc/footer.php';
+    set_flash('Token manquant.', 'danger');
+    header('Location: /login.php');
     exit;
 }
 
 $stmt = $pdo->prepare(
     "UPDATE users
        SET verify_token = NULL,
-           verified_at  = NOW()
+           verified     = 1
      WHERE verify_token = ?"
 );
 $stmt->execute([$token]);
 
 if ($stmt->rowCount()) {
-    echo '<div class="alert alert-success">Votre compte est désormais vérifié !</div>';
+    set_flash('Votre compte est désormais vérifié !', 'success');
 } else {
-    echo '<div class="alert alert-warning">Lien invalide ou déjà utilisé.</div>';
+    set_flash('Lien invalide ou déjà utilisé.', 'warning');
 }
-
-require_once 'inc/footer.php';
-?>
+header('Location: /login.php');
+exit;


### PR DESCRIPTION
## Summary
- implement `set_flash` and `display_flash` helpers
- include flash helper in header and show flash messages after nav
- fix email verification bug and redirect with flash

## Testing
- `php -l verify.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f409a0e6c8328aae55960d913f920